### PR TITLE
Adds inlets and outlets to GKE operators

### DIFF
--- a/ror_dag.py
+++ b/ror_dag.py
@@ -67,7 +67,7 @@ with DAG(
             "python3 -m pip install google-cloud-storage",
         ]
     )
-    raw_gcs_lineage_file = File(url=f"gs://{DATA_BUCKET}/{raw_jsonl_loc}")
+    raw_gcs_lineage_file = File(url=f"gcs:{DATA_BUCKET}.{raw_jsonl_loc}")
     download_data = GKEStartPodOperator(
         task_id="download_data",
         name="ror-download",
@@ -132,7 +132,7 @@ with DAG(
             ),
         ],
         inlets=[raw_gcs_lineage_file],
-        outlets=[File(url=f"gs://{DATA_BUCKET}/{jsonl_with_up}")],
+        outlets=[File(url=f"gcs:{DATA_BUCKET}.{jsonl_with_up}")],
         namespace="default",
         image=f"gcr.io/{PROJECT_ID}/cc2-task-pool",
         get_logs=True,

--- a/ror_dag.py
+++ b/ror_dag.py
@@ -115,7 +115,7 @@ with DAG(
         },
     )
 
-    jsonl_with_up = tmp_dir + "ror_json_with_up.jsonl"
+    jsonl_with_up = f"{tmp_dir}/ror_json_with_up.jsonl"
     add_ultimate_parent = GKEStartPodOperator(
         task_id="add_ultimate_parent",
         name="ror-ultimate-parent",


### PR DESCRIPTION
Closes https://github.com/georgetown-cset/eto-planning/issues/477 along with enabling dataplex in cloud composer

See also https://console.cloud.google.com/dataplex/projects/gcp-cset-projects/locations/us/entryGroups/@bigquery/entries/cHJvamVjdHMvZ2NwLWNzZXQtcHJvamVjdHMvZGF0YXNldHMvZ2NwX2NzZXRfcm9yL3RhYmxlcy9yb3I?project=gcp-cset-projects#lineage

For some reason the file inlets/outlets don't seem to be displayed fully - I am going to do a little more reading/experimentation to make sure I'm not missing something and then contact support. Data lineage in airflow is marked new/experimental in the docs so there may be some kinks to work out. That said, early returns are that this is going to be very useful. My next step will be to integrate into the pipelines that feed `literature`. Even if the file lineage doesn't work perfectly, just making BigQuery dependencies more visible would be huge

James, no need to look before our 1-1, I will show you then